### PR TITLE
Fixed FAQ Volunteer link, and added changes to Navbar for mobile

### DIFF
--- a/src/components/FAQ.jsx
+++ b/src/components/FAQ.jsx
@@ -97,7 +97,7 @@ const data = [
   },
   {
     question: 'Can I volunteer to help with the event?',
-    answer: <p>You can volunteer!  Simply sign up using the registration button at the top of the page or go <a className="underline font-bold" href="bit.ly/sfhacks2024-register">here</a> and select the volunteer option on the first page.</p>
+    answer: <p>You can volunteer!  Simply sign up using the registration button at the top of the page or go <a className="underline font-bold" href="https://bit.ly/sfhacks2024-apply">here</a> and select the volunteer option on the first page.</p>
   },
   {
     question: 'Where can I contact you for any questions or support?',

--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -21,7 +21,7 @@ const Navbar = () => {
 
                 {/* MLH Banner */}
                 <a
-                    className="hidden md:block md:w-14 lg:w-20 absolute left-40 top-0 w-1/10 z-10000"
+                    className="xs:w-14 md:block md:w-14 lg:w-20 absolute left-40 top-0 z-10000"
                     href="https://mlh.io/na?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2024-season&utm_content=red"
                     target="_blank"
                 ><img
@@ -33,7 +33,7 @@ const Navbar = () => {
             </div>
             
             {/* Right side of header */}
-            <div className="flex flex-row text-[#FFF5D9] mr-10 gap-[5vw]">
+            <div className="flex flex-row text-[#FFF5D9] mr-10 gap-[5vw] xs:text-xs mr-5">
 
                 {/* Buttons */}
                 <Link className="transition duration-200 ease-in-out delay-150 border-b-4 hover:border-[#FFF5D9] border-transparent" href="/faq/">FAQ</Link>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,9 @@ module.exports = {
   ],
   theme: {
     extend: {
+      screens: {
+        'xs':'300px', // Added an extra small screen variant
+      },
       backgroundImage: {
         "event" : "url(/brand-assets/eventPink.jpg)",
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",


### PR DESCRIPTION
Volunteer link goes straight to the register link now, and mobile has the MLH banner with a smaller version of the navbar links.